### PR TITLE
Change the upper bound of http-client to 0.4

### DIFF
--- a/pipes-http.cabal
+++ b/pipes-http.cabal
@@ -21,7 +21,7 @@ Library
         base             >= 4       && < 5   ,
         bytestring       >= 0.9.2.1 && < 0.11,
         pipes            >= 4.0     && < 4.2 ,
-        http-client      >= 0.2     && < 0.3 ,
+        http-client      >= 0.2     && < 0.4 ,
         http-client-tls                < 0.3
     Exposed-Modules: Pipes.HTTP
     GHC-Options: -O2 -Wall


### PR DESCRIPTION
It looks like pipes-http works with http-client-0.3.x.
