### PR TITLE
Allow pipes 4.2

### DIFF
--- a/pipes-http.cabal
+++ b/pipes-http.cabal
@@ -20,7 +20,7 @@ Library
     Build-Depends:
         base             >= 4       && < 5   ,
         bytestring       >= 0.9.2.1 && < 0.11,
-        pipes            >= 4.0     && < 4.2 ,
+        pipes            >= 4.0     && < 4.3 ,
         http-client      >= 0.2     && < 0.5 ,
         http-client-tls                < 0.3
     Exposed-Modules: Pipes.HTTP


### PR DESCRIPTION
pipes 4.2.0 just released, the current pipes-http builds and works fine here.